### PR TITLE
service: add fastly_package_hash per v5 upgrade

### DIFF
--- a/service.tf
+++ b/service.tf
@@ -1,3 +1,7 @@
+data "fastly_package_hash" "demo" {
+  filename = "pkg/fastly-compute-edge-demo.tar.gz"
+}
+
 resource "fastly_service_compute" "fastly_compute_edge_demo" {
   name    = "fastly-compute-edge-demo"
   comment = "Managed by chenrui333/fastly-compute-edge-demo repo"
@@ -27,14 +31,8 @@ resource "fastly_service_compute" "fastly_compute_edge_demo" {
   package {
     # `fastly-compute-edge-demo.tar.gz` is built by `fastly compute build`
     filename         = "pkg/fastly-compute-edge-demo.tar.gz"
-    source_code_hash = filesha512("pkg/fastly-compute-edge-demo.tar.gz")
+    source_code_hash = data.fastly_package_hash.demo.hash
   }
 
   force_destroy = true
-
-  lifecycle {
-    ignore_changes = [
-      package,
-    ]
-  }
 }

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,10 +1,28 @@
 {
   "version": 4,
-  "terraform_version": "1.1.7",
-  "serial": 6,
+  "terraform_version": "1.4.6",
+  "serial": 8,
   "lineage": "ba35ba47-3645-5cf5-7e34-191c61c5b6fa",
   "outputs": {},
   "resources": [
+    {
+      "mode": "data",
+      "type": "fastly_package_hash",
+      "name": "demo",
+      "provider": "provider[\"registry.terraform.io/fastly/fastly\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": null,
+            "filename": "pkg/fastly-compute-edge-demo.tar.gz",
+            "hash": "4da0c1c133f29fdfe193875d8c42a2f0b6bfd0588e175ca076e488d7258341ea3d2eba5647cac525bb16bcee898b0b75ddf5901b9f8d8886fa8637a35dc8ac2a",
+            "id": "4da0c1c133f29fdfe193875d8c42a2f0b6bfd0588e175ca076e488d7258341ea3d2eba5647cac525bb16bcee898b0b75ddf5901b9f8d8886fa8637a35dc8ac2a"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
     {
       "mode": "managed",
       "type": "fastly_service_compute",
@@ -15,16 +33,16 @@
           "schema_version": 0,
           "attributes": {
             "activate": true,
-            "active_version": 15,
+            "active_version": 45,
             "backend": [
               {
                 "address": "127.0.0.1",
-                "auto_loadbalance": false,
                 "between_bytes_timeout": 10000,
                 "connect_timeout": 1000,
                 "error_threshold": 0,
                 "first_byte_timeout": 15000,
                 "healthcheck": "",
+                "keepalive_time": 0,
                 "max_conn": 200,
                 "max_tls_version": "",
                 "min_tls_version": "",
@@ -38,19 +56,18 @@
                 "ssl_ciphers": "",
                 "ssl_client_cert": "",
                 "ssl_client_key": "",
-                "ssl_hostname": "",
                 "ssl_sni_hostname": "",
                 "use_ssl": false,
                 "weight": 100
               },
               {
                 "address": "httpbin.org",
-                "auto_loadbalance": false,
                 "between_bytes_timeout": 10000,
                 "connect_timeout": 1000,
                 "error_threshold": 0,
                 "first_byte_timeout": 15000,
                 "healthcheck": "",
+                "keepalive_time": 0,
                 "max_conn": 200,
                 "max_tls_version": "",
                 "min_tls_version": "1.2",
@@ -64,18 +81,14 @@
                 "ssl_ciphers": "",
                 "ssl_client_cert": "",
                 "ssl_client_key": "",
-                "ssl_hostname": "",
                 "ssl_sni_hostname": "httpbin.org",
                 "use_ssl": true,
                 "weight": 100
               }
             ],
-            "cloned_version": 15,
+            "cloned_version": 45,
             "comment": "Managed by chenrui333/fastly-compute-edge-demo repo",
-            "default_host": "",
-            "default_ttl": 3600,
             "dictionary": [],
-            "director": [],
             "domain": [
               {
                 "comment": "",
@@ -83,8 +96,9 @@
               }
             ],
             "force_destroy": true,
-            "healthcheck": [],
+            "force_refresh": false,
             "id": "3P8d99kmQc6GK2lpLPvtmk",
+            "imported": false,
             "logging_bigquery": [],
             "logging_blobstorage": [],
             "logging_cloudfiles": [],
@@ -114,18 +128,23 @@
             "name": "fastly-compute-edge-demo",
             "package": [
               {
+                "content": "",
                 "filename": "pkg/fastly-compute-edge-demo.tar.gz",
-                "source_code_hash": "46becb53e725ada745170603798e2ad5ef8bb9db80d480b99fe23cac4a4ed6e27c7eb807daf6b31e668780975a2408087b20f92cc5a2bc7d80174e495e00ca0a"
+                "source_code_hash": "4da0c1c133f29fdfe193875d8c42a2f0b6bfd0588e175ca076e488d7258341ea3d2eba5647cac525bb16bcee898b0b75ddf5901b9f8d8886fa8637a35dc8ac2a"
               }
             ],
-            "stale_if_error": false,
-            "stale_if_error_ttl": 43200,
+            "product_enablement": [],
+            "reuse": null,
             "version_comment": ""
           },
           "sensitive_attributes": [],
-          "private": "bnVsbA=="
+          "private": "bnVsbA==",
+          "dependencies": [
+            "data.fastly_package_hash.demo"
+          ]
         }
       ]
     }
-  ]
+  ],
+  "check_results": null
 }

--- a/terraform.tfstate.backup
+++ b/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
   "version": 4,
-  "terraform_version": "1.1.7",
-  "serial": 5,
+  "terraform_version": "1.4.6",
+  "serial": 6,
   "lineage": "ba35ba47-3645-5cf5-7e34-191c61c5b6fa",
   "outputs": {},
   "resources": [
@@ -15,7 +15,7 @@
           "schema_version": 0,
           "attributes": {
             "activate": true,
-            "active_version": 11,
+            "active_version": 15,
             "backend": [
               {
                 "address": "127.0.0.1",
@@ -70,7 +70,7 @@
                 "weight": 100
               }
             ],
-            "cloned_version": 11,
+            "cloned_version": 15,
             "comment": "Managed by chenrui333/fastly-compute-edge-demo repo",
             "default_host": "",
             "default_ttl": 3600,
@@ -115,7 +115,7 @@
             "package": [
               {
                 "filename": "pkg/fastly-compute-edge-demo.tar.gz",
-                "source_code_hash": "428ab05e56aa96ea6526b72fa57e3c1dc0301063e7fc2181fa4751bd5ea3c5966fa0583218d798db486886b6eff213ee32e57de0b69af3ef6ab68ab2a7e945a4"
+                "source_code_hash": "46becb53e725ada745170603798e2ad5ef8bb9db80d480b99fe23cac4a4ed6e27c7eb807daf6b31e668780975a2408087b20f92cc5a2bc7d80174e495e00ca0a"
               }
             ],
             "stale_if_error": false,
@@ -127,5 +127,6 @@
         }
       ]
     }
-  ]
+  ],
+  "check_results": null
 }


### PR DESCRIPTION
relates to https://github.com/fastly/terraform-provider-fastly/pull/698

release notes, https://github.com/fastly/terraform-provider-fastly/releases/tag/v5.0.0